### PR TITLE
Fix: URL-encode data_in JSON payload to prevent encoding errors in POST request

### DIFF
--- a/Exosite.agent.lib.nut
+++ b/Exosite.agent.lib.nut
@@ -291,8 +291,10 @@ class Exosite {
         writeDataHeaders["X-Exosite-CIK"]  <-  token;
         _debug("writeData: " + http.jsonencode(table));
         _debug("headers: " + http.jsonencode(_headers));
-
-        local req = http.post(format("%sonep:v1/stack/alias", _baseURL), writeDataHeaders, "data_in=" + http.jsonencode(table));
+        
+        local jsonString = http.jsonencode(table);
+        local postBody = http.urlencode({ "data_in" : jsonString });
+        local req = http.post(format("%sonep:v1/stack/alias", _baseURL), writeDataHeaders, postBody);
         req.sendasync(callback.bindenv(this));
     }
 


### PR DESCRIPTION
- Converts the table to a JSON string
- Wraps the JSON string in a one-key table ({ "data_in": ... })
- Uses http.urlencode() to produce a compliant application/x-www-form-urlencoded body
- Prevents +, &, and other special characters in JSON from being misinterpreted by the Exosite API